### PR TITLE
Point module to root index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "main": "index.js",
-  "module": "src/index.js",
+  "module": "index.js",
   "scripts": {
     "build": "standard && rollup -c rollup.config.js",
     "test": "npm run build && node test.js",


### PR DESCRIPTION
Using this module in my CRA project failed to build because it could not minify src/index.js.
The CRA script pointed me towards: https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify

This changes fixes it for me, not 100% sure if this is the correct way though.